### PR TITLE
Center images in page layout

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -18,7 +18,7 @@ export default function Card() {
         return (
           <div
             key={i}
-            className="mx-auto bg-[#8800ff]  w-5/6 flex-col flex p-6 rounded-lg shadow-2xl text-white relative md:hover:shadow-3xl mb-12 md:w-11/12 md:flex-row  md:gap-24  md:p-12"
+            className="mx-auto bg-[#8800ff]  w-5/6 flex-col flex p-6 items-center rounded-lg shadow-2xl text-white relative md:hover:shadow-3xl mb-12 md:w-11/12 md:flex-row  md:gap-24  md:p-12"
           >
             {/* image */}
             <a href={item.link}>


### PR DESCRIPTION
# Issue_No:- #33 

Added CSS styles to center images horizontally and vertically within their container 

## Before 
![image](https://user-images.githubusercontent.com/126863895/236731052-87d0b2df-b34f-45a4-8369-c915b0cb084a.png)

## After
![image](https://user-images.githubusercontent.com/126863895/236731091-3f9957f1-81e4-4f02-938e-eb8a7780fca1.png)
